### PR TITLE
Fix crash: payday source works on cached payday path

### DIFF
--- a/frontend/src/pages/Spendability.jsx
+++ b/frontend/src/pages/Spendability.jsx
@@ -182,6 +182,7 @@ const SpendabilityV2 = () => {
       }
       
       let payCycleData = payCycleDocSnap.exists() ? payCycleDocSnap.data() : null;
+	  let paydayCalcResult = null;
       // Auto-update payday if needed
       const wasUpdated = await autoUpdatePayday(settingsData);
       if (wasUpdated) {
@@ -399,6 +400,7 @@ console.log('Spendability: Using schedules', {
 });
 
 const result = PayCycleCalculator.calculateNextPayday(yoursSchedule, spouseSchedule);
+paydayCalcResult = result;
 
 console.log('Spendability: Payday calculation result', result);
 nextPayday = result.date;
@@ -497,7 +499,8 @@ console.log('🔍 PAYDAY CALCULATION DEBUG:', {
       });
       
       // Whose payday is next? Early-deposit split only applies to YOUR paycheck.
-      const paydaySource = result?.source || 'yours';
+      const paydayInfo = paydayCalcResult || payCycleData || {};
+      const paydaySource = paydayInfo.source || 'yours';
       const isSpousePayday = String(paydaySource).toLowerCase().includes('spouse');
 
       if (earlyDepositEnabled && earlyDepositAmount > 0 && !isSpousePayday) {
@@ -564,7 +567,7 @@ console.log('🔍 PAYDAY CALCULATION DEBUG:', {
       } else {
         // Single payday (default). Use the amount for WHOSE payday this is:
         // the calculator returns spouse's amount on spouse's payday.
-        const totalPayAmount = parseFloat(result?.amount) ||
+        const totalPayAmount = parseFloat(paydayInfo.amount) ||
           parseFloat(settingsData.payAmount || settingsData.paySchedules?.yours?.amount) || 0;
         
         paydays = [


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Testing Checklist
- [ ] Happy path tested ✅
- [ ] Error path tested ✅
- [ ] Edge cases considered
- [ ] Manual testing completed

## Code Quality Checklist
- [ ] All variables used in error handlers are function-scoped
- [ ] Error handlers can access userId, itemId, etc.
- [ ] No const/let declarations only in try blocks
- [ ] Console.log statements removed (using logger instead)
- [ ] ESLint passes without errors
- [ ] No new warnings introduced

## Error Handling Checklist
- [ ] All catch blocks log enough context (userId, path, etc.)
- [ ] User-facing error messages are clear
- [ ] No sensitive data in error logs
- [ ] Errors don't crash the server

## Documentation
- [ ] Code comments added for complex logic
- [ ] README updated if needed
- [ ] Breaking changes documented

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Related Issues
<!-- Link related issues: Fixes #123 -->