### PR TITLE
Add pay-cycle projection engine: safe-to-spend = lowest projected dip

### DIFF
--- a/backend/scripts/test-projection-engine.mjs
+++ b/backend/scripts/test-projection-engine.mjs
@@ -1,0 +1,130 @@
+// test-projection-engine.mjs — proves the pay-cycle projection engine's math.
+// Every expected value below was computed BY HAND before running.
+//
+//   cd backend && node scripts/test-projection-engine.mjs
+
+import {
+  projectCashFlow, nextOwnPaydays, spousePaydaysBetween, addDays,
+} from '../../frontend/src/utils/CashFlowProjection.js';
+
+let pass = 0, fail = 0;
+const check = (label, actual, expected) => {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  ok ? pass++ : fail++;
+  console.log(`${ok ? '✅' : '❌'} ${label}${ok ? '' : `\n     expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`}`);
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+console.log('\n— basic walk: bills + daily essentials, no income —');
+// balance 1000, 6 days (7/16→7/21), one $300 bill on 7/20, essentials $70/wk
+// = $10/day, buffer $100. Hand-walked: 990,980,970,960,650,640 → min 640.
+{
+  const r = projectCashFlow({
+    startingBalance: 1000, todayStr: '2026-07-16', cycleEndStr: '2026-07-21',
+    bills: [{ name: 'Big Bill', amount: 300, dueDate: '2026-07-20' }],
+    incomes: [], weeklyEssentials: 70, safetyBuffer: 100,
+  });
+  check('min balance is 640 on the last day', [r.minBalance, r.minDate], [640, '2026-07-21']);
+  check('safeToSpend = min − buffer = 540', r.safeToSpend, 540);
+  check('cycle is 6 days', r.daysInCycle, 6);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+console.log('\n— THE KEY INSIGHT: a dip before mid-cycle income limits spending —');
+// balance 500; $400 bill on day 2; $1000 income day 4. Ending balance is fat
+// ($1100) but the dip to $100 before the income is what limits safe-to-spend.
+{
+  const r = projectCashFlow({
+    startingBalance: 500, todayStr: '2026-07-16', cycleEndStr: '2026-07-20',
+    bills: [{ name: 'Rent', amount: 400, dueDate: '2026-07-17' }],
+    incomes: [{ date: '2026-07-19', amount: 1000, label: 'Spouse payday' }],
+    weeklyEssentials: 0, safetyBuffer: 0,
+  });
+  check('dip bottoms at 100 on the bill day', [r.minBalance, r.minDate], [100, '2026-07-17']);
+  check('safeToSpend is the DIP (100), not the ending balance (1100)', r.safeToSpend, 100);
+  check('ending balance is 1100', r.endBalance, 1100);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+console.log('\n— overdue bills claim money TODAY —');
+{
+  const r = projectCashFlow({
+    startingBalance: 1000, todayStr: '2026-07-16', cycleEndStr: '2026-07-18',
+    bills: [{ name: 'Old Bill', amount: 250, dueDate: '2026-07-01' }],
+    incomes: [], weeklyEssentials: 0, safetyBuffer: 0,
+  });
+  check('overdue $250 applied on day one', r.ledger[0].bills, 250);
+  check('safeToSpend reflects it immediately', r.safeToSpend, 750);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+console.log('\n— bills beyond the cycle end are excluded —');
+{
+  const r = projectCashFlow({
+    startingBalance: 1000, todayStr: '2026-07-16', cycleEndStr: '2026-07-18',
+    bills: [{ name: 'Next Cycle Bill', amount: 999, dueDate: '2026-07-25' }],
+    incomes: [], weeklyEssentials: 0, safetyBuffer: 0,
+  });
+  check('out-of-window bill ignored', r.totalBills, 0);
+  check('safeToSpend untouched', r.safeToSpend, 1000);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+console.log('\n— spouse payday generator: 15th & 30th, Feb clamps to 28th —');
+{
+  const july = spousePaydaysBetween('2026-07-10', '2026-07-31', 1892.26).map(x => x.date);
+  check('July window contains 15th and 30th', july, ['2026-07-15', '2026-07-30']);
+
+  const feb = spousePaydaysBetween('2026-02-01', '2026-02-28', 1892.26).map(x => x.date);
+  check('February clamps 30th to the 28th', feb, ['2026-02-15', '2026-02-28']);
+
+  const excl = spousePaydaysBetween('2026-07-15', '2026-07-20', 1892.26).map(x => x.date);
+  check('payday ON today is excluded (already in balance)', excl, []);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+console.log('\n— own next paydays from a bi-weekly anchor —');
+{
+  const r = nextOwnPaydays('2026-07-10', '2026-07-16', { earlyDepositEnabled: true, daysBeforePayday: 2 });
+  check('main payday advances to 7/24', r.mainDate, '2026-07-24');
+  check('early deposit lands 7/22', r.earlyDate, '2026-07-22');
+
+  const onPayday = nextOwnPaydays('2026-07-10', '2026-07-24', {});
+  check("on payday morning, next main is 8/7 (today's pay is in balance)", onPayday.mainDate, '2026-08-07');
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+console.log('\n— GOLDEN SCENARIO: Steve-shaped week, hand-computed —');
+// Balance $1,821.55 on 7/16. Own pay: last 7/10, early-deposit 2 days before
+// main 7/24 → own money arrives 7/22, cycle = 7/16..7/21 (6 days).
+// Tanci's 15th passed, 30th is outside → no income in window.
+// Bills in window: Citi 200 (16th), Peacock 10.99 (17th), Geico 307.89 (18th),
+// SiriusXM 13.32 (18th), Disney+ 18.99 (19th)  → total 551.19.
+// Essentials $230/wk → 32.857142.../day × 6 = 197.142857...
+// End/min = 1821.55 − 551.19 − 197.142857 = 1073.217142... → 1073.22
+// Safe = 1073.22 − 200 buffer = 873.22
+{
+  const { mainDate, earlyDate } = nextOwnPaydays('2026-07-10', '2026-07-16', { earlyDepositEnabled: true, daysBeforePayday: 2 });
+  const cycleEndStr = addDays(earlyDate || mainDate, -1);
+  check('cycle end computed as 7/21', cycleEndStr, '2026-07-21');
+
+  const r = projectCashFlow({
+    startingBalance: 1821.55, todayStr: '2026-07-16', cycleEndStr,
+    incomes: spousePaydaysBetween('2026-07-16', cycleEndStr, 1892.26),
+    bills: [
+      { name: 'Citi Card - Costco Card', amount: 200, dueDate: '2026-07-16' },
+      { name: 'Peacock', amount: 10.99, dueDate: '2026-07-17' },
+      { name: 'Geico Charger Durango Challenger', amount: 307.89, dueDate: '2026-07-18' },
+      { name: 'SiriusXM', amount: 13.32, dueDate: '2026-07-18' },
+      { name: 'Disney Plus', amount: 18.99, dueDate: '2026-07-19' },
+    ],
+    weeklyEssentials: 230, safetyBuffer: 200,
+  });
+  check('no spouse income lands in this window', r.totalIncome, 0);
+  check('window bills total 551.19', r.totalBills, 551.19);
+  check('lowest point 1073.22 (hand-computed)', r.minBalance, 1073.22);
+  check('SAFE TO SPEND = 873.22 (hand-computed)', r.safeToSpend, 873.22);
+}
+
+console.log(`\n${pass} passed, ${fail} failed\n`);
+process.exit(fail ? 1 : 0);

--- a/frontend/src/pages/Spendability.jsx
+++ b/frontend/src/pages/Spendability.jsx
@@ -3,6 +3,7 @@ import { doc, getDoc, updateDoc, collection, addDoc, getDocs, serverTimestamp, a
 import { db } from '../firebase';
 import { PayCycleCalculator } from '../utils/PayCycleCalculator';
 import { RecurringBillManager } from '../utils/RecurringBillManager';
+import { projectCashFlow, nextOwnPaydays, spousePaydaysBetween, addDays } from '../utils/CashFlowProjection';
 import { formatDateForDisplay, formatDateForInput, getDaysUntilDateInPacific, getManualPacificDaysUntilPayday } from '../utils/DateUtils';
 import { getPacificTime } from '../utils/timezoneHelpers';
 import { autoMigrateBills } from '../utils/FirebaseMigration';
@@ -32,6 +33,7 @@ const SpendabilityV2 = () => {
     totalBillsDue: 0,
     safeToSpend: 0,
     safeToSpendToday: 0,
+    projection: null,
     availableAfterPayday: 0,
     // depositsTodayAmount removed - not needed anymore
     nextPayday: 'No date',
@@ -801,13 +803,55 @@ console.log('🔍 PAYDAY CALCULATION DEBUG:', {
       const weeksUntilPayday = Math.ceil(daysUntilPayday / 7);
       const essentialsNeeded = weeklyEssentials * weeksUntilPayday;
 
-      // ✅ CORRECT: Safe to spend NOW uses ONLY real bank balance from Plaid
-      // Future deposits are NOT included until they actually arrive in the bank
-      const safeToSpendToday = 
-        totalAvailable -           // Real balance that's ACTUALLY in the bank
-        totalBillsDue -            // Only unpaid bills
-        essentialsNeeded -         // Weekly essentials
-        safetyBuffer;              // Safety buffer
+      // ═══════════ PAY-CYCLE PROJECTION ENGINE ═══════════
+      // Day-by-day running balance from today through the day BEFORE the
+      // user's own next money arrives (early deposit if enabled, else main
+      // payday). Spouse paydays inside the window are mid-cycle income; all
+      // unpaid bills in the window (including overdue) are outflows on their
+      // dates; essentials drip daily. Safe-to-spend = the LOWEST projected
+      // dip minus the safety buffer — the spreadsheet algorithm.
+      const todayStrProj = new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'America/Los_Angeles'
+      }).format(new Date());
+
+      const ownLastPay = settingsData.lastPayDate || settingsData.paySchedules?.yours?.lastPaydate;
+      const { mainDate: ownMainNext, earlyDate: ownEarlyNext } = nextOwnPaydays(
+        ownLastPay, todayStrProj,
+        { earlyDepositEnabled, daysBeforePayday }
+      );
+      const ownBoundary = ownEarlyNext || ownMainNext;   // first own money arrival
+      const cycleEndStr = ownBoundary ? addDays(ownBoundary, -1) : nextPayday;
+
+      const spouseAmt = parseFloat(
+        settingsData.paySchedules?.spouse?.amount || settingsData.spouseAmount
+      ) || 0;
+      const cycleIncomes = spousePaydaysBetween(todayStrProj, cycleEndStr, spouseAmt);
+
+      const allUnpaidCycleBills = [
+        ...(unpaidBillsBeforePayday || []),
+        ...(unpaidBillsAfterPayday || []),
+      ];
+
+      const projection = projectCashFlow({
+        startingBalance: totalAvailable,
+        todayStr: todayStrProj,
+        cycleEndStr,
+        incomes: cycleIncomes,
+        bills: allUnpaidCycleBills,
+        weeklyEssentials,
+        safetyBuffer,
+      });
+
+      console.log('📈 PAY-CYCLE PROJECTION:', {
+        cycle: `${todayStrProj} → ${cycleEndStr} (${projection.daysInCycle} days)`,
+        ownNextMoney: ownBoundary,
+        cycleIncome: projection.totalIncome,
+        cycleBills: projection.totalBills,
+        lowestPoint: `$${projection.minBalance} on ${projection.minDate}`,
+        safeToSpend: projection.safeToSpend,
+      });
+
+      const safeToSpendToday = projection.safeToSpend;
       
       // Calculate what will be available AFTER all deposits arrive (projection)
       const availableAfterPayday = 
@@ -938,6 +982,14 @@ console.log('🔍 PAYDAY CALCULATION DEBUG:', {
         totalBillsDue,  // Total of unpaid bills only
         safeToSpend,
         safeToSpendToday,  // NEW: What's safe to spend RIGHT NOW
+        projection: {
+          cycleEnd: cycleEndStr,
+          minDate: projection.minDate,
+          minBalance: projection.minBalance,
+          totalCycleBills: projection.totalBills,
+          cycleIncome: projection.totalIncome,
+          daysInCycle: projection.daysInCycle,
+        },
         availableAfterPayday,  // NEW: What will be available after all deposits
         // depositsTodayAmount removed
         nextPayday,
@@ -966,6 +1018,7 @@ console.log('🔍 PAYDAY CALCULATION DEBUG:', {
     totalBillsDue: 0,
     safeToSpend: 0,
     safeToSpendToday: 0,
+    projection: null,
     availableAfterPayday: 0,
     // depositsTodayAmount removed
     nextPayday: 'Not set',
@@ -1314,7 +1367,9 @@ console.log('🔍 PAYDAY CALCULATION DEBUG:', {
               {financialData.safeToSpendToday < 0 && <span className="warning-badge">⚠️ SHORT</span>}
             </div>
             <div className="spend-note">
-              Based on current bank balance (updates automatically)
+              {financialData.projection
+                ? `Covers every bill through ${financialData.projection.cycleEnd} (${financialData.projection.daysInCycle} days) · tightest day: ${financialData.projection.minDate}`
+                : 'Based on current bank balance (updates automatically)'}
             </div>
           </div>
           

--- a/frontend/src/utils/CashFlowProjection.js
+++ b/frontend/src/utils/CashFlowProjection.js
@@ -1,0 +1,190 @@
+/**
+ * CashFlowProjection.js
+ *
+ * The pay-cycle projection engine — implements the day-by-day running-balance
+ * method (a.k.a. "the spreadsheet algorithm"):
+ *
+ *   The pay cycle is anchored to the USER'S OWN paycheck. It runs from today
+ *   through the day before the user's next own money arrives (the early
+ *   deposit if enabled, else the main payday). Spouse paydays that land
+ *   inside the window are mid-cycle INCOME. Every unpaid bill in the window
+ *   (including overdue ones, applied immediately) is an outflow on its due
+ *   date. Weekly essentials drip out daily. Safe-to-spend is the LOWEST
+ *   point the projected balance ever touches, minus the safety buffer —
+ *   because money you spend today must survive every dip between now and
+ *   refill, not just the average.
+ *
+ * Pure functions, no I/O — fully unit-testable.
+ */
+
+const DAY_MS = 86400000;
+
+/** Parse YYYY-MM-DD as a calendar day anchored at UTC noon (TZ/DST-immune). */
+export function parseDay(str) {
+  return new Date(String(str).slice(0, 10) + 'T12:00:00Z');
+}
+
+/** Format a Date back to YYYY-MM-DD. */
+export function fmtDay(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Add n calendar days to a YYYY-MM-DD string. */
+export function addDays(str, n) {
+  const d = parseDay(str);
+  d.setUTCDate(d.getUTCDate() + n);
+  return fmtDay(d);
+}
+
+/** Whole calendar days from a to b (b - a). */
+export function daysBetween(aStr, bStr) {
+  return Math.round((parseDay(bStr) - parseDay(aStr)) / DAY_MS);
+}
+
+/**
+ * Next OWN paydays strictly after `todayStr`, from a bi-weekly anchor.
+ * Returns { mainDate, earlyDate } (earlyDate null when early deposit is off).
+ */
+export function nextOwnPaydays(lastPayDateStr, todayStr, {
+  earlyDepositEnabled = false,
+  daysBeforePayday = 1,
+} = {}) {
+  if (!lastPayDateStr) return { mainDate: null, earlyDate: null };
+  let main = String(lastPayDateStr).slice(0, 10);
+  let guard = 0;
+  while (main <= todayStr && guard++ < 120) main = addDays(main, 14);
+  const early = earlyDepositEnabled ? addDays(main, -Math.abs(daysBeforePayday || 1)) : null;
+  return { mainDate: main, earlyDate: early };
+}
+
+/**
+ * Spouse paydays (15th & 30th; 30th clamps to month-end for February) that
+ * fall inside (todayStr, endStr] — i.e., strictly after today, up to and
+ * including the cycle end.
+ */
+export function spousePaydaysBetween(todayStr, endStr, amount) {
+  if (!amount || !endStr || endStr < todayStr) return [];
+  const out = [];
+  const start = parseDay(todayStr);
+  const end = parseDay(endStr);
+  // Walk months from start's month to end's month
+  const cursor = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 1, 12));
+  while (cursor <= end) {
+    const y = cursor.getUTCFullYear(), m = cursor.getUTCMonth();
+    const lastDom = new Date(Date.UTC(y, m + 1, 0, 12)).getUTCDate();
+    for (const dom of [15, Math.min(30, lastDom)]) {
+      const dStr = fmtDay(new Date(Date.UTC(y, m, dom, 12)));
+      if (dStr > todayStr && dStr <= endStr) {
+        out.push({ date: dStr, amount: Number(amount), label: 'Spouse payday' });
+      }
+    }
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+  return out;
+}
+
+/**
+ * The core projection.
+ *
+ * @param {Object} p
+ * @param {number} p.startingBalance   Current real total available balance
+ * @param {string} p.todayStr          YYYY-MM-DD
+ * @param {string} p.cycleEndStr       Last day of the cycle (day before own next money)
+ * @param {Array}  p.incomes           [{date, amount, label}] inside (today, cycleEnd]
+ * @param {Array}  p.bills             Unpaid bills [{name, amount, dueDate}] — overdue
+ *                                     (dueDate < today) are applied on day 0
+ * @param {number} p.weeklyEssentials  Dollars/week for groceries/gas/needs (dripped daily)
+ * @param {number} p.safetyBuffer      Minimum balance floor
+ *
+ * @returns {Object} {
+ *   safeToSpend, minBalance, minDate, endBalance,
+ *   totalBills, totalIncome, essentialsTotal, daysInCycle,
+ *   ledger: [{date, income, bills, essentials, balance, events[]}]
+ * }
+ */
+export function projectCashFlow({
+  startingBalance = 0,
+  todayStr,
+  cycleEndStr,
+  incomes = [],
+  bills = [],
+  weeklyEssentials = 0,
+  safetyBuffer = 0,
+}) {
+  const daysInCycle = Math.max(0, daysBetween(todayStr, cycleEndStr)) + 1; // inclusive of today
+  const essentialsDaily = (Number(weeklyEssentials) || 0) / 7;
+
+  // Index incomes and bills by date; overdue bills land on day 0 (today)
+  const incomeByDate = new Map();
+  for (const inc of incomes) {
+    const d = String(inc.date).slice(0, 10);
+    if (d <= todayStr || d > cycleEndStr) continue; // only future income inside window
+    if (!incomeByDate.has(d)) incomeByDate.set(d, []);
+    incomeByDate.get(d).push(inc);
+  }
+
+  const billsByDate = new Map();
+  for (const b of bills) {
+    const raw = String(b.dueDate || b.nextDueDate || b.date || '').slice(0, 10);
+    if (!raw) continue;
+    if (raw > cycleEndStr) continue;                 // outside this cycle
+    const d = raw < todayStr ? todayStr : raw;        // overdue → hits today
+    if (!billsByDate.has(d)) billsByDate.set(d, []);
+    billsByDate.get(d).push(b);
+  }
+
+  const ledger = [];
+  let balance = Number(startingBalance) || 0;
+  let minBalance = Infinity;
+  let minDate = todayStr;
+  let totalBills = 0;
+  let totalIncome = 0;
+
+  for (let i = 0; i < daysInCycle; i++) {
+    const date = addDays(todayStr, i);
+    const dayIncomes = incomeByDate.get(date) || [];
+    const dayBills = billsByDate.get(date) || [];
+
+    const incomeSum = dayIncomes.reduce((s, x) => s + (Number(x.amount) || 0), 0);
+    const billSum = dayBills.reduce((s, x) => s + Math.abs(Number(x.amount ?? x.cost) || 0), 0);
+
+    balance += incomeSum;
+    balance -= billSum;
+    balance -= essentialsDaily;
+
+    totalIncome += incomeSum;
+    totalBills += billSum;
+
+    if (balance < minBalance) {
+      minBalance = balance;
+      minDate = date;
+    }
+
+    ledger.push({
+      date,
+      income: incomeSum,
+      bills: billSum,
+      essentials: essentialsDaily,
+      balance: Math.round(balance * 100) / 100,
+      events: [
+        ...dayIncomes.map(x => `+ ${x.label || 'Income'} $${Number(x.amount).toFixed(2)}`),
+        ...dayBills.map(x => `- ${x.name} $${Math.abs(Number(x.amount ?? x.cost) || 0).toFixed(2)}`),
+      ],
+    });
+  }
+
+  if (minBalance === Infinity) minBalance = balance;
+
+  const round2 = (n) => Math.round(n * 100) / 100;
+  return {
+    safeToSpend: round2(minBalance - (Number(safetyBuffer) || 0)),
+    minBalance: round2(minBalance),
+    minDate,
+    endBalance: round2(balance),
+    totalBills: round2(totalBills),
+    totalIncome: round2(totalIncome),
+    essentialsTotal: round2(essentialsDaily * daysInCycle),
+    daysInCycle,
+    ledger,
+  };
+}


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## Testing Checklist
- [ ] Happy path tested ✅
- [ ] Error path tested ✅
- [ ] Edge cases considered
- [ ] Manual testing completed

## Code Quality Checklist
- [ ] All variables used in error handlers are function-scoped
- [ ] Error handlers can access userId, itemId, etc.
- [ ] No const/let declarations only in try blocks
- [ ] Console.log statements removed (using logger instead)
- [ ] ESLint passes without errors
- [ ] No new warnings introduced

## Error Handling Checklist
- [ ] All catch blocks log enough context (userId, path, etc.)
- [ ] User-facing error messages are clear
- [ ] No sensitive data in error logs
- [ ] Errors don't crash the server

## Documentation
- [ ] Code comments added for complex logic
- [ ] README updated if needed
- [ ] Breaking changes documented

## Screenshots (if applicable)
<!-- Add screenshots here -->

## Related Issues
<!-- Link related issues: Fixes #123 -->